### PR TITLE
Fix single route api

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -23,7 +23,10 @@ gulp.task('webpack', () => {
 });
 
 gulp.task('webpack:watch', ['webpack'], () => {
-  gulp.watch('./static/js/**/**.js*', ['webpack']);
+  gulp.watch(
+    ['./static/js/**/**.js*', './static/stylesheets/*'],
+    ['sass', 'webpack'],
+  );
 });
 
 gulp.task('default', ['webpack', 'sass']);

--- a/app.py
+++ b/app.py
@@ -31,7 +31,7 @@ class RoutesListAPI(MethodView):
         response = requests.get(self.endpoint)
         response.raise_for_status()
         route_list = response.json()
-        return json.jsonify(*route_list)
+        return json.jsonify(route_list)
 
     def post(self):
         """

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,3 +5,13 @@ services:
     build: .
     ports:
       - ${CERYX_WEB_EXTERNAL_PORT:-7777}:5000
+    volumes:
+      - ./:/usr/src/app
+    environment:
+      - FLASK_DEBUG=1
+  builder:
+    image: node:8
+    command: bash -c 'yarn && yarn run webpack:watch'
+    working_dir: /usr/src/app
+    volumes:
+      - ./:/usr/src/app


### PR DESCRIPTION
Add a fix, where single routes in the API would return the response as a single dict, instead of a single element array, which was crashing the client.

Also, add sass building to `webpack:watch` and improve the Docker Compose setup for easier development.